### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: :index
 
   def index
-    # @items = Item.order('created_at DESC')
+    @items = Item.includes(:user).order('created_at DESC')
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,39 +126,54 @@
     <%= link_to '新規投稿商品', new_item_path , class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <% @items.each do |item| %>
-        <li class='list'>
-          <%= link_to "#" do %>
-            <div class='item-img-content'>
-              <%= image_tag item.image.variant(resize: '500x500'), class: "item-img" if item.image.attached? %>
-              <%# 商品が売れていればsold outを表示しましょう %>
-              <%# <div class='sold-out'> %>
-              <%# <span>Sold Out!!</span> %>
-              <%# </div> %>
-              <%# //商品が売れていればsold outを表示しましょう %>
+      <%# 商品データがある場合は、eachメソッドで一覧表示する %>
+    <% @items.each do |item| %>
+      <li class='list'>
+        <%= link_to "#" do %>
+        <div class='item-img-content'>
+        <%= image_tag item.image.variant(resize: '500x500'), class: "item-img" if item.image.attached? %>
+          <%# 商品が売れていればsold outを表示しましょう %>
+          <%# <div class='sold-out'> %>
+            <%# <span>Sold Out!!</span> %>
+          <%# </div> %>
+          <%# //商品が売れていればsold outを表示しましょう %>
             </div>
-            <div class='item-info'>
-              <h3 class='item-name'>
-               <%= item.name %>
-               </h3>
-              <div class='item-price'>
-                  <span><%= item.price %>円<br><%= item.shipping_cost.name %></span>
-                  <div class='star-btn'>
-                  <%= image_tag "star.png", class:"star-icon" %>
-                  <span class='star-count'>0</span>
-              </div>
-             </div>
+        <div class='item-info'>
+          <h3 class='item-name'>
+            <%= item.name %>
+          </h3>
+          <div class='item-price'>
+            <span><%= item.price %>円<br><%= item.shipping_cost.name %></span>
+            <div class='star-btn'>
+              <%= image_tag "star.png", class:"star-icon" %>
+              <span class='star-count'>0</span>
             </div>
-          <% end %>
-        </li>
+          </div>
+        </div>
+        <% end %>
+      </li>
       <% end %>
+
+  <%# 商品がない場合はダミーを表示する %>
+    <% if @items.blank? then %>
+      <li class='list'>
+        <%= link_to '#' do %>
+        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
+        <div class='item-info'>
+          <h3 class='item-name'>
+            商品を出品してね！
+          </h3>
+          <div class='item-price'>
+            <span>99999999円<br>(税込み)</span>
+            <div class='star-btn'>
+              <%= image_tag "star.png", class:"star-icon" %>
+              <span class='star-count'>0</span>
+        <% end %>
+      </li>
+    <% end %>
     </ul>
   </div>
-  <%# /商品一覧 %>
 </div>
-
 <%= link_to(new_item_path, class: 'purchase-btn') do %>
   <span class='purchase-btn-text'>出品する</span>
   <%= image_tag 'icon_camera.png' , size: '185x50' ,class: "purchase-btn-icon" %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,63 +123,42 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+    <%= link_to '新規投稿商品', new_item_path , class: "subtitle" %>
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+      <% @items.each do |item| %>
+        <li class='list'>
+          <%= link_to "#" do %>
+            <div class='item-img-content'>
+              <%= image_tag item.image.variant(resize: '500x500'), class: "item-img" if item.image.attached? %>
+              <%# 商品が売れていればsold outを表示しましょう %>
+              <%# <div class='sold-out'> %>
+              <%# <span>Sold Out!!</span> %>
+              <%# </div> %>
+              <%# //商品が売れていればsold outを表示しましょう %>
             </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+            <div class='item-info'>
+              <h3 class='item-name'>
+               <%= item.name %>
+               </h3>
+              <div class='item-price'>
+                  <span><%= item.price %>円<br><%= item.shipping_cost.name %></span>
+                  <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+              </div>
+             </div>
             </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# /商品がない場合のダミー %>
+          <% end %>
+        </li>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>
 </div>
+
 <%= link_to(new_item_path, class: 'purchase-btn') do %>
   <span class='purchase-btn-text'>出品する</span>
   <%= image_tag 'icon_camera.png' , size: '185x50' ,class: "purchase-btn-icon" %>


### PR DESCRIPTION
# What
- ログイン有無に関わらず、トップページで出品登録した商品が表示されるように実装した。

# Why
- トップページで出品した商品一覧を見られるようにするため。
- 欲しい商品を見て新規登録を促すため。

【確認動画】
●ログイン中に表示確認
https://gyazo.com/20f08176ae26232d4c4de2e6034d1403

●ログアウト中に表示確認
https://gyazo.com/c8cdbf4c9421ed3304fbe655b2fc2365
