### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,9 @@
 class ItemsController < ApplicationController
   # ログインしていないユーザーはトップページに促す
   before_action :authenticate_user!, except: :index
+  # 重複処理をまとめる
+  before_action :set_item, only: :show
+  # before_action :set_item, only: [:edit, :show]
 
   def index
     @items = Item.includes(:user).order('created_at DESC')
@@ -19,9 +22,29 @@ class ItemsController < ApplicationController
     end
   end
 
+  # def destroy
+  #   item = Item.find(params[:id])
+  #   item.destroy
+  # end
+
+  # def edit
+  # end
+
+  # def update
+  #   item = Item.find(params[:id])
+  #   item.update(item_params)
+  # end
+
+  def show
+  end
+
   private
 
   def item_params
     params.require(:item).permit(:image, :name, :description, :category_id, :item_status_id, :shipping_cost_id, :delivery_area_id, :shipping_date_id, :price).merge(user_id: current_user.id)
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   # ログインしていないユーザーはトップページに促す
-  before_action :authenticate_user!, except: :index
+  before_action :authenticate_user!, except: [:index, :show]
   # 重複処理をまとめる
   before_action :set_item, only: :show
   # before_action :set_item, only: [:edit, :show]

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,7 +129,7 @@
       <%# 商品データがある場合は、eachメソッドで一覧表示する %>
     <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item) do %>
         <div class='item-img-content'>
         <%= image_tag item.image.variant(resize: '500x500'), class: "item-img" if item.image.attached? %>
           <%# 商品が売れていればsold outを表示しましょう %>
@@ -137,7 +137,7 @@
             <%# <span>Sold Out!!</span> %>
           <%# </div> %>
           <%# //商品が売れていればsold outを表示しましょう %>
-            </div>
+        </div>
         <div class='item-info'>
           <h3 class='item-name'>
             <%= item.name %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -47,7 +47,7 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= current_user.nickname %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -38,7 +38,7 @@
   <% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
@@ -103,7 +103,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,34 +4,38 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image.variant(resize: '500x500'),class:"item-box-img" %>
+  
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class='sold-out'>
+      <%# <div class='sold-out'>
         <span>Sold Out!!</span>
-      </div>
+      </div> %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>円
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        <%= @item.shipping_cost.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+  <% if user_signed_in? && current_user.id == @item.user_id %>
+    <%= link_to '商品の編集', '#', method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
+    <%= link_to '削除', '#', method: :delete, class:'item-destroy' %>
+  <% else %>
+  <%# <% elsif Buy.created_id.blank? then %> 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <%= link_to '購入画面に進む', '#', class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
+  <% end %>
 
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
@@ -43,27 +47,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= current_user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.item_status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_cost.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.delivery_area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.shipping_date.name%></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,21 +24,18 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-  <% if user_signed_in? && current_user.id == @item.user_id %>
-    <%= link_to '商品の編集', '#', method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', '#', method: :delete, class:'item-destroy' %>
-  <% else %>
-  <%# <% elsif Buy.created_id.blank? then %> 
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', '#', class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
+<%# 新規登録していない人でも詳細画面を見られるが以下のボタンは登録者のみ %>
+  <% if user_signed_in? %> 
+    <%# 商品の編集・削除ができるのは、本人のみ %>
+    <% if current_user.id == @item.user_id then %>
+      <%= link_to '商品の編集', '#', method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', '#', method: :delete, class:'item-destroy' %>
+    <% else %>
+    <%# 商品の購入ができるのは、出品者以外のみ %>
+      <%= link_to '購入画面に進む', '#', class:"item-red-btn"%>
+    <% end %>
   <% end %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>


### PR DESCRIPTION
# What
- トップページから商品に関する部分を押すと詳細画面が表示されるよう実装（新規登録していない人でも可能）
- ログインしている本人の場合には「編集」「削除」ボタンの表示、本人以外の場合には「購入に進む」ボタンの表示の実装
- 商品詳細の下には、商品に応じた情報が展開されるよう実装
# Why
- 販売者側は販売している商品情報の確認・削除のため、購入者側は欲しい商品の詳細を知るために実装


---実装確認動画---

【出品者本人の場合】フリマ太郎は、赤い服を出品した
https://gyazo.com/15057de28af76c8782718cd949bdde30
【出品者本人以外の場合】フリマ太郎は、他の人が出品したぶどうが欲しい
https://gyazo.com/5d57ae7ba71d6da051bdee039d7fc5ab